### PR TITLE
Serialize attributes into ActionController::Parameters instead of Hash

### DIFF
--- a/app/models/opro/oauth/auth_grant.rb
+++ b/app/models/opro/oauth/auth_grant.rb
@@ -16,12 +16,12 @@ class Opro::Oauth::AuthGrant < ActiveRecord::Base
 
   alias_attribute :token, :access_token
 
-  serialize :permissions, Hash
+  serialize :permissions, ActionController::Parameters
 
   # attr_accessible :code, :access_token, :refresh_token, :access_token_expires_at, :permissions, :user_id, :user, :application_id, :application
 
   def can?(value)
-    HashWithIndifferentAccess.new(permissions)[value]
+    permissions.to_unsafe_h.with_indifferent_access[value]
   end
 
   def expired?


### PR DESCRIPTION
- Fix for Rails 5 upgrade
- We were getting exception ```ActiveRecord::SerializationTypeMismatch - Attribute was supposed to be a Hash, but was a ActionController::Parameters. -- <ActionController::Parameters {"write"=>"1"} permitted: false>``` on authorization request 
- Serialize attributes into ActionController::Parameters instead of Hash