### PR TITLE
Fix serialization of permissions

### DIFF
--- a/app/controllers/opro/oauth/auth_controller.rb
+++ b/app/controllers/opro/oauth/auth_controller.rb
@@ -15,7 +15,7 @@ class Opro::Oauth::AuthController < OproController
     auth_grant  = Opro::Oauth::AuthGrant.find_or_create_by_user_app(current_user, application)
 
     # add permission changes if there are any
-    auth_grant.update_permissions(params[:permissions])
+    auth_grant.update_permissions(params[:permissions]&.to_unsafe_h)
     redirect_to auth_grant.redirect_uri_for(params[:redirect_uri], params[:state])
   end
 

--- a/app/controllers/opro/oauth/token_controller.rb
+++ b/app/controllers/opro/oauth/token_controller.rb
@@ -12,7 +12,13 @@ class Opro::Oauth::TokenController < OproController
 
     if application.present? && (@auth_grant = auth_grant_for(application, params)).present?
       @auth_grant.refresh!
-      render :create
+
+      render json: {
+        access_token: @auth_grant.access_token,
+        token_type: Opro.token_type || 'bearer',
+        refresh_token: @auth_grant.refresh_token,
+        expires_in: @auth_grant.expires_in
+      }
     else
       render_error debug_msg(params, application)
     end


### PR DESCRIPTION
- Fix for Rails 5 upgrade
- We were getting exception ```ActiveRecord::SerializationTypeMismatch - Attribute was supposed to be a Hash, but was a ActionController::Parameters. -- <ActionController::Parameters {"write"=>"1"} permitted: false>``` on authorization request 
- Serialize ```ActionController::Parameters``` into ```Hash``` before sending it to ```AuthGrant#update_permissions``` as permissions is serialized as Hash for ```AuthGrant```
- Fix the weird problem of rendering JSON with create token request, we don't really need a view